### PR TITLE
fix: improve URL validation and readability in documentation

### DIFF
--- a/scripts/getVersion.js
+++ b/scripts/getVersion.js
@@ -95,7 +95,7 @@ function getUpdateInfo(jsonStr) {
     try {
         const data = JSON.parse(jsonStr);
         return {
-            text: `| 微信 ${data.version} for Android  | (${data.publishDate}) | [${data.downloadUrl}](${data.downloadUrl}) |`,
+            text: `| 微信 ${data.version} for Android  | (${data.publishDate}) | [${data.version} Android](${data.downloadUrl}) |`,
             version_info: `微信 ${data.version} for Android`,
             url: data.downloadUrl,
             fileName: data.downloadUrl.split('/').pop(),

--- a/scripts/validate.js
+++ b/scripts/validate.js
@@ -4,7 +4,7 @@ const readmeFilePath = './README.md';
 const versionFilePath = './version.json';
 
 function extractUrlsFromReadme(content) {
-    const pattern = /^\|[^|]+\|[^|]+\|\s*\[[^\]]+\]\((https:\/\/dldir1v6\.qq\.com\/weixin\/android\/[^)]+)\)\s*\|/gm;
+    const pattern = /^\|[^|]+\|[^|]+\|\s*\[[^\]]+\]\((https:\/\/dldir1(v6)?\.qq\.com\/weixin\/android\/[^)]+)\)\s*\|/gm;
     const urls = [];
     let match;
     while ((match = pattern.exec(content)) !== null) {


### PR DESCRIPTION
### Summary of Changes
- Updated the URL extraction regex in `scripts/validate.js` to correctly identify and validate WeChat Android download links from both `dldir1.qq.com` and `dldir1v6.qq.com` domains.
- Modified `scripts/getVersion.js` to generate a cleaner, more readable Markdown link label (e.g., "[8.0.74 Android]") for new entries in `README.md` instead of using the full, lengthy download URL as the link text.

### Rationale
- **Robustness:** The previous regex in `scripts/validate.js` was too restrictive, leading to incomplete duplicate URL detection by ignoring entries from the `dldir1` domain.
- **Readability:** Presenting the full URL as link text in the `README.md` table makes the table difficult to read. Replacing it with a version-based label significantly improves user experience and table aesthetics.

### Technical Impact Analysis
- Enhances the reliability of the validation suite, ensuring that the project maintains a cleaner and more accurate record of version history.
- Modernizes the output format of the documentation without impacting the functional logic of the version tracking scripts.